### PR TITLE
Fixed URL

### DIFF
--- a/export_halo_users_to_SSO.rb
+++ b/export_halo_users_to_SSO.rb
@@ -12,7 +12,7 @@ host = 'api.cloudpassage.com'
 # setup a API session
 client = OAuth2::Client.new(clientid, clientsecret,
                 :site => "https://#{host}",
-                :token_url => '/oauth/access_token')
+                :token_url => '/oauth/access_token?grant_type=client_credentials')
 
 token = client.client_credentials.get_token.token
 
@@ -31,7 +31,7 @@ CSV.open('halo_user_import.csv', 'w') do |csv|
     csv << [user['firstname'], user['lastname'], user['email'], user['username']]
   end
 end
-  
+
 # output the file for quick review/validation
 File.readlines('halo_user_import.csv').each do |line|
 end


### PR DESCRIPTION
I was trying to get this script to work so I could dump out all the users.  Is the `/users` deprecated? Any chance it just gotten moved?

I found a reference to it in the PDF and on this [page](https://support.cloudpassage.com/entries/23110911-Overview), see screen shot:

<img width="1124" alt="screen shot 2015-08-12 at 9 48 52 pm" src="https://cloud.githubusercontent.com/assets/903511/9242759/f939a096-413b-11e5-9bf7-76940b733ca0.png">

Let me know what's up.